### PR TITLE
feat: Add ability to delete closed ballots from dashboard

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -8,6 +8,7 @@ import { SignInForm } from "../SignInForm";
 export function Dashboard() {
   const userBallots = useQuery(api.ballots.getUserBallots);
   const closeBallot = useMutation(api.ballots.closeBallot);
+  const deleteBallot = useMutation(api.ballots.deleteBallot);
 
   const handleCloseBallot = async (ballotId: string) => {
     try {
@@ -15,6 +16,19 @@ export function Dashboard() {
       toast.success("Ballot closed successfully");
     } catch (error: any) {
       toast.error(error.message || "Failed to close ballot");
+    }
+  };
+
+  const handleDeleteBallot = async (ballotId: string, ballotTitle: string) => {
+    if (!confirm(`Are you sure you want to delete "${ballotTitle}"? This action cannot be undone.`)) {
+      return;
+    }
+
+    try {
+      await deleteBallot({ ballotId: ballotId as any });
+      toast.success("Ballot deleted successfully");
+    } catch (error: any) {
+      toast.error(error.message || "Failed to delete ballot");
     }
   };
 
@@ -70,6 +84,14 @@ export function Dashboard() {
                             className="text-red-600 hover:text-red-700 text-sm font-medium ml-4"
                           >
                             Close Ballot
+                          </button>
+                        )}
+                        {!ballot.isActive && (
+                          <button
+                            onClick={() => handleDeleteBallot(ballot._id, ballot.title)}
+                            className="text-red-600 hover:text-red-700 text-sm font-medium ml-4"
+                          >
+                            Delete Ballot
                           </button>
                         )}
                       </div>


### PR DESCRIPTION
## Summary

This PR implements the ability for users to delete closed ballots from their dashboard, providing better ballot management capabilities.

## Changes Made

### Backend (`convex/ballots.ts`)
- Added `deleteBallot` mutation with comprehensive validation:
  - User authentication required
  - Authorization check (only ballot creators can delete)
  - Safety check (only closed ballots can be deleted)
  - Cascading deletion of related data (votes and user activity records)

### Frontend (`src/components/Dashboard.tsx`)
- Added delete functionality to the dashboard:
  - Delete button appears only for closed ballots
  - Confirmation dialog with ballot title for safety
  - Proper error handling and success feedback
  - Integration with existing UI patterns

## Key Features

✅ **Safety First**: Only closed ballots can be deleted
✅ **Authorization**: Users can only delete ballots they created
✅ **Data Integrity**: Cascading deletion removes all related records
✅ **User Experience**: Confirmation dialog and clear feedback
✅ **UI Integration**: Consistent with existing dashboard design

## Testing

To test this feature:
1. Create a ballot and close it
2. Verify the "Delete Ballot" button appears on the dashboard
3. Test the confirmation dialog
4. Confirm the ballot and related data are properly removed

## Security Considerations

- Only authenticated users can delete ballots
- Users can only delete ballots they created
- Active ballots cannot be deleted (must be closed first)
- All related data is properly cleaned up to prevent orphaned records

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author